### PR TITLE
1.4.0 compability

### DIFF
--- a/StorageGuru/ContentManager.cs
+++ b/StorageGuru/ContentManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using UnityEngine;
+using UnityEngine.ImageConversionModule;
 
 namespace StorageGuru
 {
@@ -42,7 +43,7 @@ namespace StorageGuru
             {
                 byte[] iconBytes = File.ReadAllBytes(filepath);
                 Texture2D tex = new Texture2D(0, 0);
-                tex.LoadImage(iconBytes);
+                tex.LoadImage(tex, iconBytes);
                 return Util.applyColor(tex);
             }
 


### PR DESCRIPTION
Fixes #25
`LoadImage()` was moved to a different location between Unity releases and now requires and extra argument. Unable to test this PR so for now this will be a draft. Feel free to test if you are able.